### PR TITLE
fix tab group render dep list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.11] - 2022-10-26
+
+### Fixed
+
+- 🗿 `TabGroup`: fix tab content doesn't get re-render, same as #45
+
 ## [1.6.10] - 2022-10-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ducduchy-react-components",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "license": "MIT",
   "author": "Duc Phan",
   "main": "dist/index.js",

--- a/src/components/TabGroup/TabGroup.tsx
+++ b/src/components/TabGroup/TabGroup.tsx
@@ -127,28 +127,36 @@ export const TabGroup = forwardRef<HTMLDivElement, TabGroupProps>(
             )
           );
         }),
-      [selectedIndex, renderArr, tabActiveIndicatorType],
+      [
+        selectedIndex,
+        renderArr,
+        tabActiveIndicatorType,
+        getTabProps,
+        renderTab,
+        renderWholeTab,
+      ],
     );
 
     const panelList = useMemo(
       () =>
         renderArr.map((_, index) => {
           const isSelected = index === selectedIndex;
+          const tabPanelProps = getTabPanelProps?.(index, isSelected);
           return (
             <Tab.Panel
-              {...getTabPanelProps?.(index, isSelected)}
+              {...tabPanelProps}
               key={index}
               className={cx(
                 "tab-group__tab-panel",
                 { "tab-group__tab-panel--selected": isSelected },
-                getTabPanelProps?.(index, isSelected)?.className,
+                tabPanelProps?.className,
               )}
             >
               {renderTabPanel(index, isSelected)}
             </Tab.Panel>
           );
         }),
-      [renderArr, selectedIndex],
+      [renderArr, selectedIndex, getTabPanelProps, renderTabPanel],
     );
 
     return (


### PR DESCRIPTION
## [1.6.11] - 2022-10-26

### Fixed

- 🗿 `TabGroup`: fix tab content doesn't get re-render, same as #45

## [1.6.10] - 2022-10-26

### Changed

- 🐱‍👤 `MaskedInput`: make `nonce` prop optional