### PR TITLE
1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2023-06-06
+
+### Added
+
+- ⛓️ `Link`: add `hideUnderlineByDefault` to hide underline by default - #62
+
+### Fixed
+
+- ⛓️ `Link`: remove icon's margin if there is no content - #63
+
 ## [1.9.1] - 2023-05-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ducduchy-react-components",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "MIT",
   "author": "Duc Phan",
   "main": "dist/index.js",

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -13,6 +13,7 @@
       @apply w-full;
     }
   }
+
   &:active::after {
     @apply w-full;
     height: 2px;
@@ -27,7 +28,7 @@
     content: "";
   }
 
-  &::before {
+  &.dd-link--show-underline::before {
     @apply w-full;
   }
   &::after {
@@ -53,11 +54,11 @@
     }
   }
 
-  > .dd-link__icon--start {
+  > .dd-link__icon--start:not(:only-child) {
     @apply mr-2;
   }
 
-  > .dd-link__icon--end {
+  > .dd-link__icon--end:not(:only-child) {
     @apply ml-2;
   }
 }

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -14,6 +14,8 @@ export interface LinkProps
   iconEnd?: IconProps["icon"] | ReactNode;
   /** Not necessary if ReactNode is provided as `iconEnd` */
   iconEndClassName?: string;
+  /** Should we hide underline by default and only show underline on hover/focus, etc */
+  hideUnderlineByDefault?: boolean;
 }
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
@@ -24,6 +26,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       iconEnd,
       iconEndClassName,
       colorType = "primary",
+      hideUnderlineByDefault,
       children,
       ...linkProps
     },
@@ -36,6 +39,10 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
         className={cx(
           `${COMPONENT_PREFIX}-link`,
           `${COMPONENT_PREFIX}-link--${colorType}`,
+          {
+            [`${COMPONENT_PREFIX}-link--show-underline`]:
+              !hideUnderlineByDefault,
+          },
           linkProps.className,
         )}
       >


### PR DESCRIPTION
## [1.9.2] - 2023-06-06

### Added

- ⛓️ `Link`: add `hideUnderlineByDefault` to hide underline by default - #62

### Fixed

- ⛓️ `Link`: remove icon's margin if there is no content - #63