### PR TITLE
fix(Input): onChange not fired with correct value for controlled form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2024-04-06
+
+### Fixed
+
+- 📝 `Input`: don't make ` onChange`` go through debounce if  `debounceParam`` is not set
+
 ## [1.10.0] - 2023-06-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ducduchy-react-components",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "MIT",
   "author": "Duc Phan",
   "main": "dist/index.js",

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -4,6 +4,7 @@ import { Input, InputProps } from ".";
 import { Button } from "../Button";
 import { storyIconOption } from "../resources/story-common";
 import "./Input.stories.scss";
+import { useState } from "react";
 
 const meta: Meta<InputProps> = {
   title: "Components/Form/Input",
@@ -94,6 +95,35 @@ export const WithUseFormSetValue: StoryFn<InputProps> = (args) => {
         <br />
         OR you can pass the `hasContent` prop to control the label float
         yourself
+      </p>
+    </div>
+  );
+};
+
+export const Controlled: StoryFn<InputProps> = (args) => {
+  const [curValue, setCurValue] = useState("Hello world!");
+
+  return (
+    <div>
+      <Input
+        {...args}
+        label="A controlled form"
+        value={curValue}
+        onChange={(event) => setCurValue(event.target.value)}
+      />
+
+      <p className="mt-4">
+        <strong>Current value:</strong> {curValue}
+      </p>
+
+      <p className="mt-8">
+        Note that this will break if you pass the <code>debounceParam</code>{" "}
+        prop because the value of the event will be lost after debounce time.
+      </p>
+      <p>
+        The reason is because the <code>event</code> object when debounce
+        finishes will use the current input value at that time which is the old
+        value
       </p>
     </div>
   );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -178,7 +178,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           !!event.target.value,
       );
 
-      debounceRef.current(event);
+      if (debounceParam?.debounceTime) {
+        debounceRef.current(event);
+      } else {
+        inputProps?.onChange?.(event);
+      }
     };
 
     useEffect(() => {


### PR DESCRIPTION
## [1.10.1] - 2024-04-06

### Fixed

- 📝 `Input`: don't make ` onChange`` go through debounce if  `debounceParam`` is not set